### PR TITLE
default the simulation to 250 ticks, 30 agents and all update and seed

### DIFF
--- a/src/02-lens/config.ini
+++ b/src/02-lens/config.ini
@@ -3,9 +3,9 @@ ModelOutput: network_of_agents.pout
 # UpdateAlgo: default
 
 [ModelParameters]
-NumberOfTimeTicks: 1000
-NumberOfAgentsToUpdatePerTimeTick: 1
-NumberOfAgentsToSeedOnInit: 1
+NumberOfTimeTicks: 250
+NumberOfAgentsToUpdatePerTimeTick: 30
+NumberOfAgentsToSeedOnInit: 30
 # 'simultaneous' or 'sequential' updating
 UpdateType: simultaneous
 
@@ -14,7 +14,7 @@ UpdateType: simultaneous
 ##################################################
 # Parameters in the batch sweep config
 ##################################################
-NumberOfAgents: 50
+NumberOfAgents: 30
 
 ##################################################
 # Parameters NOT in the batch sweep config


### PR DESCRIPTION
what should have been in this PR but isn't due to a rebase:

c04ea463f9268efcbf8a244eb2e3e49c03e1f438
005b9e251faf8c885c101c6bdd84a89144f450c6
74d1dad8c3c713a82b4a5a731b6c6f18e5c2fdac
fed4a7ab4efab4481e5d8402bd1e88e8fd6422e4
4c5428f3bddb45530cbee91b2ba9f6aa9ba61371
029ff6092010ba53a1afa817432ed76d526d6b30

